### PR TITLE
Try to fix pypi long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import find_packages, setup
 
-with open('README.md') as f:
+# read the contents of your README file
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Linked to #11 
Perhaps an encoding issue. If still not work we should check the [tools versions required](https://packaging.python.org/guides/making-a-pypi-friendly-readme/) to deploy on pypi.org.